### PR TITLE
feat(market): load products list

### DIFF
--- a/apps/market/src/App.tsx
+++ b/apps/market/src/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Catalog from './components/Catalog'
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
         <li><code>npm run build</code> — сборка</li>
         <li><code>npm run preview</code> — предпросмотр сборки</li>
       </ul>
+      <Catalog />
     </div>
   )
 }

--- a/apps/market/src/api/products.ts
+++ b/apps/market/src/api/products.ts
@@ -1,0 +1,18 @@
+export interface Product {
+  id: number;
+  title: string;
+  price: number;
+}
+
+export interface ProductList {
+  items: Product[];
+  total: number;
+}
+
+export async function fetchProducts(): Promise<ProductList> {
+  const response = await fetch('/api/v1/products');
+  if (!response.ok) {
+    throw new Error('Failed to fetch products');
+  }
+  return response.json() as Promise<ProductList>;
+}

--- a/apps/market/src/components/Catalog.tsx
+++ b/apps/market/src/components/Catalog.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import ProductCard from './ProductCard';
+import { fetchProducts, Product } from '../api/products';
+
+export default function Catalog() {
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    fetchProducts()
+      .then((data) => {
+        setProducts(data.items);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }, []);
+
+  return (
+    <div>
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
+    </div>
+  );
+}

--- a/apps/market/src/components/ProductCard.tsx
+++ b/apps/market/src/components/ProductCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { Product } from '../api/products';
+
+interface ProductCardProps {
+  product: Product;
+}
+
+export default function ProductCard({ product }: ProductCardProps) {
+  return (
+    <div style={{ border: '1px solid #ddd', padding: 12, borderRadius: 4, marginBottom: 12 }}>
+      <h3 style={{ margin: '0 0 8px' }}>{product.title}</h3>
+      <span>{product.price} ₽</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add products API client and types
- show catalog and product cards loaded from API

## Testing
- `npm --workspace apps/market run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0c5a7458083298ace1517028dab3e