### PR TITLE
feat(market): add catalog pages and routing

### DIFF
--- a/apps/market/package.json
+++ b/apps/market/package.json
@@ -10,13 +10,14 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
-    "vite": "^5.3.0",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.23",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.5.0",
-    "@types/react": "^18.2.66",
-    "@types/react-dom": "^18.2.23"
+    "vite": "^5.3.0"
   }
 }

--- a/apps/market/src/components/Layout.tsx
+++ b/apps/market/src/components/Layout.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Link, Outlet } from 'react-router-dom'
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: 720,
+  margin: '40px auto',
+  fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, sans-serif',
+}
+
+const navStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 16,
+  marginBottom: 24,
+}
+
+export default function Layout() {
+  return (
+    <div style={containerStyle}>
+      <nav style={navStyle}>
+        <Link to="/">Каталог</Link>
+        <Link to="/cart">Корзина</Link>
+      </nav>
+      <Outlet />
+    </div>
+  )
+}

--- a/apps/market/src/components/ProductCard.tsx
+++ b/apps/market/src/components/ProductCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import type { Product } from '../data/products'
+
+interface Props {
+  product: Product
+}
+
+export default function ProductCard({ product }: Props) {
+  return (
+    <div style={{ border: '1px solid #ddd', padding: 16, borderRadius: 4 }}>
+      <h3 style={{ margin: '0 0 8px' }}>
+        <Link to={`/product/${product.id}`}>{product.title}</Link>
+      </h3>
+      <p style={{ margin: 0 }}>{product.price.toFixed(2)} ₽</p>
+    </div>
+  )
+}

--- a/apps/market/src/data/products.ts
+++ b/apps/market/src/data/products.ts
@@ -1,0 +1,27 @@
+export interface Product {
+  id: string
+  title: string
+  description: string
+  price: number
+}
+
+export const products: Product[] = [
+  {
+    id: '1',
+    title: 'Увлажняющий крем',
+    description: 'Нежный крем для ежедневного ухода.',
+    price: 299,
+  },
+  {
+    id: '2',
+    title: 'Тоник для лица',
+    description: 'Освежающий тоник для всех типов кожи.',
+    price: 199,
+  },
+  {
+    id: '3',
+    title: 'Маска для волос',
+    description: 'Питательная маска для восстановления волос.',
+    price: 399,
+  },
+]

--- a/apps/market/src/main.tsx
+++ b/apps/market/src/main.tsx
@@ -1,10 +1,24 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
+import Layout from './components/Layout'
+import Catalog from './pages/Catalog'
+import Product from './pages/Product'
+import Cart from './pages/Cart'
+import Checkout from './pages/Checkout'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<Catalog />} />
+          <Route path="product/:id" element={<Product />} />
+          <Route path="cart" element={<Cart />} />
+          <Route path="checkout" element={<Checkout />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>,
 )

--- a/apps/market/src/pages/Cart.tsx
+++ b/apps/market/src/pages/Cart.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Cart() {
+  return <div>Ваша корзина пуста.</div>
+}

--- a/apps/market/src/pages/Catalog.tsx
+++ b/apps/market/src/pages/Catalog.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ProductCard from '../components/ProductCard'
+import { products } from '../data/products'
+
+export default function Catalog() {
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      {products.map((p) => (
+        <ProductCard key={p.id} product={p} />
+      ))}
+    </div>
+  )
+}

--- a/apps/market/src/pages/Checkout.tsx
+++ b/apps/market/src/pages/Checkout.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function Checkout() {
+  return <div>Оформление заказа.</div>
+}

--- a/apps/market/src/pages/Product.tsx
+++ b/apps/market/src/pages/Product.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import { products } from '../data/products'
+
+export default function Product() {
+  const { id } = useParams<{ id: string }>()
+  const product = products.find((p) => p.id === id)
+
+  if (!product) {
+    return <div>Товар не найден</div>
+  }
+
+  return (
+    <div>
+      <h2>{product.title}</h2>
+      <p>{product.description}</p>
+      <p>{product.price.toFixed(2)} ₽</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add basic layout and product card components
- implement catalog, product, cart and checkout pages
- wire up react-router routes in main entry

## Testing
- `npm --workspace apps/market run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0c5a72e048329b1daa467898fa36f