### PR TITLE
feat: add global scss support for market app

### DIFF
--- a/apps/market/package.json
+++ b/apps/market/package.json
@@ -17,6 +17,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.5.0",
     "@types/react": "^18.2.66",
-    "@types/react-dom": "^18.2.23"
+    "@types/react-dom": "^18.2.23",
+    "sass": "^1.77.0"
   }
 }

--- a/apps/market/src/index.css
+++ b/apps/market/src/index.css
@@ -1,3 +1,0 @@
-:root { line-height: 1.5; }
-* { box-sizing: border-box; }
-body { margin: 0; }

--- a/apps/market/src/main.tsx
+++ b/apps/market/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import './index.css'
+import './styles/base.scss'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/market/src/styles/_mixins.scss
+++ b/apps/market/src/styles/_mixins.scss
@@ -1,0 +1,25 @@
+// Media query mixins
+@mixin mobile {
+  @media (max-width: 600px) {
+    @content;
+  }
+}
+
+@mixin tablet {
+  @media (min-width: 601px) and (max-width: 1024px) {
+    @content;
+  }
+}
+
+@mixin desktop {
+  @media (min-width: 1025px) {
+    @content;
+  }
+}
+
+// Reusable patterns
+@mixin flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/apps/market/src/styles/_variables.scss
+++ b/apps/market/src/styles/_variables.scss
@@ -1,0 +1,19 @@
+// Color palette
+$color-primary: #ff6b6b;
+$color-secondary: #4ecdc4;
+$color-accent: #ffe66d;
+$color-text: #333333;
+$color-background: #f7f7f7;
+
+// Typography
+$font-family-base: 'Helvetica Neue', Arial, sans-serif;
+$font-size-base: 16px;
+$font-weight-normal: 400;
+$font-weight-bold: 700;
+
+// Spacing
+$spacing-xs: 4px;
+$spacing-sm: 8px;
+$spacing-md: 16px;
+$spacing-lg: 24px;
+$spacing-xl: 32px;

--- a/apps/market/src/styles/base.scss
+++ b/apps/market/src/styles/base.scss
@@ -1,0 +1,18 @@
+@import './variables';
+@import './mixins';
+
+:root {
+  line-height: 1.5;
+  font-family: $font-family-base;
+  font-size: $font-size-base;
+  color: $color-text;
+  background-color: $color-background;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- add SCSS variables, mixins, and base styles for market app
- enable global SCSS import in entry file and remove old CSS
- include sass tooling dependency

## Testing
- `npm --workspace apps/market run build`
- `npm --workspace apps/market test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0c5a6763c8329b4113dccb4183879