### PR TITLE
feat(market): add layout and product components with SCSS modules

### DIFF
--- a/apps/market/package.json
+++ b/apps/market/package.json
@@ -13,10 +13,11 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "vite": "^5.3.0",
-    "@vitejs/plugin-react": "^4.3.0",
-    "typescript": "^5.5.0",
     "@types/react": "^18.2.66",
-    "@types/react-dom": "^18.2.23"
+    "@types/react-dom": "^18.2.23",
+    "@vitejs/plugin-react": "^4.3.0",
+    "sass-embedded": "^1.90.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.3.0"
   }
 }

--- a/apps/market/src/App.tsx
+++ b/apps/market/src/App.tsx
@@ -1,17 +1,27 @@
-import React from 'react'
+import React from 'react';
+import Layout from './components/Layout';
+import ProductCard from './components/ProductCard';
+
+const products = [
+  { id: 1, title: 'Product 1', price: '$10', image: 'https://via.placeholder.com/300x200?text=1' },
+  { id: 2, title: 'Product 2', price: '$20', image: 'https://via.placeholder.com/300x200?text=2' },
+  { id: 3, title: 'Product 3', price: '$30', image: 'https://via.placeholder.com/300x200?text=3' },
+  { id: 4, title: 'Product 4', price: '$40', image: 'https://via.placeholder.com/300x200?text=4' },
+  { id: 5, title: 'Product 5', price: '$50', image: 'https://via.placeholder.com/300x200?text=5' }
+];
 
 export default function App() {
   return (
-    <div style={{ maxWidth: 720, margin: '40px auto', fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, sans-serif' }}>
-      <h1 style={{ marginBottom: 8 }}>Клиент маркетплейса — MIRA</h1>
-      <p style={{ lineHeight: 1.6 }}>
-        Пустой шаблон на Vite + React + TypeScript. Здесь можно строить UI.
-      </p>
-      <ul>
-        <li><code>npm run dev</code> — запуск dev-сервера</li>
-        <li><code>npm run build</code> — сборка</li>
-        <li><code>npm run preview</code> — предпросмотр сборки</li>
-      </ul>
-    </div>
-  )
+    <Layout>
+      {products.map((p) => (
+        <ProductCard
+          key={p.id}
+          image={p.image}
+          title={p.title}
+          price={p.price}
+          onAdd={() => console.log(`Add ${p.title}`)}
+        />
+      ))}
+    </Layout>
+  );
 }

--- a/apps/market/src/components/Footer.module.scss
+++ b/apps/market/src/components/Footer.module.scss
@@ -1,0 +1,14 @@
+$footer-bg: #f9f9f9;
+$footer-border: #e5e5e5;
+
+@mixin center {
+  text-align: center;
+}
+
+.footer {
+  @include center;
+  padding: 1rem;
+  background: $footer-bg;
+  border-top: 1px solid $footer-border;
+  font-size: 0.875rem;
+}

--- a/apps/market/src/components/Footer.tsx
+++ b/apps/market/src/components/Footer.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from './Footer.module.scss';
+
+const Footer: React.FC = () => {
+  return (
+    <footer className={styles.footer}>
+      © {new Date().getFullYear()} MIRA Market
+    </footer>
+  );
+};
+
+export default Footer;

--- a/apps/market/src/components/Header.module.scss
+++ b/apps/market/src/components/Header.module.scss
@@ -1,0 +1,15 @@
+$header-bg: #ffffff;
+$header-border: #e5e5e5;
+
+@mixin flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header {
+  @include flex-center;
+  padding: 1rem;
+  background: $header-bg;
+  border-bottom: 1px solid $header-border;
+}

--- a/apps/market/src/components/Header.tsx
+++ b/apps/market/src/components/Header.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from './Header.module.scss';
+
+const Header: React.FC = () => {
+  return (
+    <header className={styles.header}>
+      <h1>MIRA Market</h1>
+    </header>
+  );
+};
+
+export default Header;

--- a/apps/market/src/components/Layout.module.scss
+++ b/apps/market/src/components/Layout.module.scss
@@ -1,0 +1,37 @@
+$gap: 1rem;
+
+@mixin container {
+  width: 100%;
+  margin: 0 auto;
+  padding: $gap;
+}
+
+@mixin grid-cols($cols) {
+  grid-template-columns: repeat($cols, 1fr);
+}
+
+.layout {
+  @include container;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.content {
+  flex: 1;
+  display: grid;
+  gap: $gap;
+  @include grid-cols(1);
+
+  @media (min-width: 600px) {
+    @include grid-cols(2);
+  }
+
+  @media (min-width: 900px) {
+    @include grid-cols(3);
+  }
+
+  @media (min-width: 1200px) {
+    @include grid-cols(4);
+  }
+}

--- a/apps/market/src/components/Layout.tsx
+++ b/apps/market/src/components/Layout.tsx
@@ -1,0 +1,20 @@
+import React, { type ReactNode } from 'react';
+import Header from './Header';
+import Footer from './Footer';
+import styles from './Layout.module.scss';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout: React.FC<LayoutProps> = ({ children }) => {
+  return (
+    <div className={styles.layout}>
+      <Header />
+      <main className={styles.content}>{children}</main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Layout;

--- a/apps/market/src/components/ProductCard.module.scss
+++ b/apps/market/src/components/ProductCard.module.scss
@@ -1,0 +1,46 @@
+$primary-color: #007bff;
+$radius: 8px;
+
+@mixin button-reset {
+  border: none;
+  cursor: pointer;
+}
+
+@mixin shadow {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.card {
+  border: 1px solid #e5e5e5;
+  border-radius: $radius;
+  padding: 1rem;
+  text-align: center;
+  background: #fff;
+  @include shadow;
+}
+
+.image {
+  width: 100%;
+  height: auto;
+  margin-bottom: 0.5rem;
+}
+
+.title {
+  font-size: 1rem;
+  margin: 0.5rem 0;
+}
+
+.price {
+  color: $primary-color;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.cta {
+  @include button-reset;
+  @include shadow;
+  background: $primary-color;
+  color: #fff;
+  padding: 0.5rem;
+  border-radius: $radius;
+}

--- a/apps/market/src/components/ProductCard.tsx
+++ b/apps/market/src/components/ProductCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styles from './ProductCard.module.scss';
+
+export interface ProductCardProps {
+  image: string;
+  title: string;
+  price: string;
+  onAdd: () => void;
+}
+
+const ProductCard: React.FC<ProductCardProps> = ({ image, title, price, onAdd }) => {
+  return (
+    <div className={styles.card}>
+      <img src={image} alt={title} className={styles.image} />
+      <h3 className={styles.title}>{title}</h3>
+      <p className={styles.price}>{price}</p>
+      <button className={styles.cta} onClick={onAdd}>
+        Add to cart
+      </button>
+    </div>
+  );
+};
+
+export default ProductCard;

--- a/apps/market/src/styles.d.ts
+++ b/apps/market/src/styles.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.scss' {
+  const classes: { [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
## Summary
- add Layout, Header, Footer, and ProductCard components
- style components with SCSS modules using variables, mixins, and responsive grid
- add sass-embedded for SCSS compilation

## Testing
- `npm --workspace apps/market run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0c5a661b883298ec2f35e8e0b4360